### PR TITLE
fixed issue 19

### DIFF
--- a/app/src/main/java/communi/dog/aplicatiion/DB.java
+++ b/app/src/main/java/communi/dog/aplicatiion/DB.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -176,7 +177,12 @@ public class DB implements Serializable {
 
     public void updateUser(String userId, String userEmail, String userPassword, String userName, String phoneNumber, String dogName, String userDescription) {
         User newUser = new User(userId, userEmail, userPassword, userName, phoneNumber, dogName, userDescription);
-        this.usersRef.child(userId).setValue(newUser);
+        this.usersRef.child(userId).setValue(newUser).addOnSuccessListener(new OnSuccessListener<Void>() {
+            @Override
+            public void onSuccess(Void aVoid) {
+                currentUser = newUser;
+            }
+        });
     }
 
     public boolean idDoubleUser(String id) {

--- a/app/src/main/java/communi/dog/aplicatiion/DB.java
+++ b/app/src/main/java/communi/dog/aplicatiion/DB.java
@@ -180,7 +180,13 @@ public class DB implements Serializable {
         this.usersRef.child(userId).setValue(newUser).addOnSuccessListener(new OnSuccessListener<Void>() {
             @Override
             public void onSuccess(Void aVoid) {
-                currentUser = newUser;
+                if(newUser.getId().equals(currentUser.getId())){
+                    currentUser = newUser;
+                }
+                else
+                {
+                    System.out.println("not the current user");
+                }
             }
         });
     }

--- a/app/src/main/java/communi/dog/aplicatiion/DB.java
+++ b/app/src/main/java/communi/dog/aplicatiion/DB.java
@@ -185,7 +185,7 @@ public class DB implements Serializable {
                 }
                 else
                 {
-                    System.out.println("not the current user");
+                    Log.d("sameUserCheck", "not the current user");
                 }
             }
         });

--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -72,8 +72,17 @@ public class ProfilePageActivity extends AppCompatActivity {
         btnEditProfile.setOnClickListener(v -> {
             if (isEdit) {
                 btnCancelEdit.setVisibility(View.GONE);
-                // this.appDB.updateUser(userId, email, password, name, phone, dogName, bio); //todo: add
-                //todo: save changes to DB
+                // solving issue #19
+                String userId = currentUser.getId();
+                String password = currentUser.getPassword();
+                String name = currentUser.getUserName();
+
+                // get from user input
+                String email = emailEditText.getText().toString();
+                String phone = phoneEditText.getText().toString();
+                String bio = bioEditText.getText().toString();
+                String dogName = dogNameEditText.getText().toString();
+                this.appDB.updateUser(userId, email, password, name, phone, dogName, bio);
             } else {
                 btnCancelEdit.setVisibility(View.VISIBLE);
                 dogNameBeforeEdit = dogNameEditText.getText().toString();
@@ -158,6 +167,7 @@ public class ProfilePageActivity extends AppCompatActivity {
         Intent backToMapIntent = new Intent(ProfilePageActivity.this, MapScreenActivity.class);
         backToMapIntent.putExtra("center_to_my_location", false);
         startActivity(backToMapIntent);
+        finish();
     }
 
     @Override

--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -72,7 +72,7 @@ public class ProfilePageActivity extends AppCompatActivity {
         btnEditProfile.setOnClickListener(v -> {
             if (isEdit) {
                 btnCancelEdit.setVisibility(View.GONE);
-                // solving issue #19
+                // save updated user to DB
                 String userId = currentUser.getId();
                 String password = currentUser.getPassword();
                 String name = currentUser.getUserName();

--- a/app/src/main/java/communi/dog/aplicatiion/RegisterActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/RegisterActivity.java
@@ -184,20 +184,26 @@ public class RegisterActivity extends AppCompatActivity {
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString("userID", id.getText().toString());
-        outState.putString("userEmail", emailAddress.getText().toString());
-        outState.putString("userPass1", pass1.getText().toString());
-        outState.putString("userPass2", pass2.getText().toString());
-        outState.putString("userName", userName.getText().toString());
+        // as part of fix for issue 19 - no longer needed
+        // because every time we enter this screen we take the data from firebase
+
+//        outState.putString("userID", id.getText().toString());
+//        outState.putString("userEmail", emailAddress.getText().toString());
+//        outState.putString("userPass1", pass1.getText().toString());
+//        outState.putString("userPass2", pass2.getText().toString());
+//        outState.putString("userName", userName.getText().toString());
     }
 
     @Override
     protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-        id.setText(savedInstanceState.getString("userID"));
-        emailAddress.setText(savedInstanceState.getString("userEmail"));
-        pass1.setText(savedInstanceState.getString("userPass1"));
-        pass2.setText(savedInstanceState.getString("userPass2"));
-        userName.setText(savedInstanceState.getString("userName"));
+        // as part of fix for issue 19 - no longer needed
+        // because every time we enter this screen we take the data from firebase
+
+//        id.setText(savedInstanceState.getString("userID"));
+//        emailAddress.setText(savedInstanceState.getString("userEmail"));
+//        pass1.setText(savedInstanceState.getString("userPass1"));
+//        pass2.setText(savedInstanceState.getString("userPass2"));
+//        userName.setText(savedInstanceState.getString("userName"));
     }
 }


### PR DESCRIPTION
issue 19 fixed - now when re-entering the user profile screen we get the data that was recently saved.
notes:
* when saving i added to the db createUser request the new user and ONLY when the request succeeds i change the current user field of the db - this is the correct behavior so that we will be with same data as db.
* saving state in profile page no longer needed since we get the updated data from firebase in the OnCreate of profileActivity