### PR TITLE
Fixed the scrolling bug in user's profile bio. bug #67

### DIFF
--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -55,7 +55,8 @@ public class ProfilePageActivity extends AppCompatActivity {
         dogNameEditText.setEnabled(false);
         emailEditText.setEnabled(false);
         phoneEditText.setEnabled(false);
-        bioEditText.setEnabled(false);
+        bioEditText.setFocusableInTouchMode(false);
+        bioEditText.clearFocus();
 
         usernameEditText.setText(currentUser.getUserName());
         dogNameEditText.setText(currentUser.getUserDogName());
@@ -150,7 +151,8 @@ public class ProfilePageActivity extends AppCompatActivity {
             btnCancelEdit.setVisibility(View.GONE);
         }
         dogNameEditText.setEnabled(isEditState);
-        bioEditText.setEnabled(isEditState);
+        bioEditText.setFocusableInTouchMode(isEditState);
+        bioEditText.clearFocus();
         emailEditText.setEnabled(isEditState);
         phoneEditText.setEnabled(isEditState);
         int edit_ic = isEditState ? R.drawable.ic_save_profile : R.drawable.ic_edit_profile;


### PR DESCRIPTION
Fixed bug #67.
The problem was that you disable the edittext (where bio is) when the user is not in edit mode.
When edittext is disable you cant scroll down.
The fix is: when edit mode is disable, only disable the editable of the edittext but allowing scrolling.