### PR TITLE
Fixed the scrolling bug in user's profile bio. bug #67

### DIFF
--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -55,7 +55,8 @@ public class ProfilePageActivity extends AppCompatActivity {
         dogNameEditText.setEnabled(false);
         emailEditText.setEnabled(false);
         phoneEditText.setEnabled(false);
-        bioEditText.setEnabled(false);
+        bioEditText.setFocusableInTouchMode(false);
+        bioEditText.clearFocus();
 
         usernameEditText.setText(currentUser.getUserName());
         dogNameEditText.setText(currentUser.getUserDogName());
@@ -150,7 +151,8 @@ public class ProfilePageActivity extends AppCompatActivity {
             btnCancelEdit.setVisibility(View.GONE);
         }
         dogNameEditText.setEnabled(isEditState);
-        bioEditText.setEnabled(isEditState);
+        bioEditText.setFocusableInTouchMode(isEditState);
+        bioEditText.clearFocus();
         emailEditText.setEnabled(isEditState);
         phoneEditText.setEnabled(isEditState);
         int edit_ic = isEditState ? R.drawable.ic_save_profile : R.drawable.ic_edit_profile;

--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.method.KeyListener;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -27,6 +28,7 @@ public class ProfilePageActivity extends AppCompatActivity {
     private ImageView btnCancelEdit;
     private boolean isEdit = false;
     private DB appDB;
+    private KeyListener bioEditTextKeyListener;
 
     private String dogNameBeforeEdit;
     private String emailBeforeEdit;
@@ -46,17 +48,19 @@ public class ProfilePageActivity extends AppCompatActivity {
         emailEditText = findViewById(R.id.usersEmailMyProfile);
         phoneEditText = findViewById(R.id.usersPhoneMyProfile);
         bioEditText = findViewById(R.id.profile_bio);
+        bioEditTextKeyListener = bioEditText.getKeyListener();
 
         btnMyMarker = findViewById(R.id.profile_to_my_marker);
         btnBackToMap = findViewById(R.id.backToMapFromProfile);
         btnCancelEdit = findViewById(R.id.btnCancelEditProfile);
+        // getting the profile bio edit text key listener. (this way we will enable and disable the
+        // option to edit it)
         btnEditProfile = findViewById(R.id.btnEditProfile);
 
         dogNameEditText.setEnabled(false);
         emailEditText.setEnabled(false);
         phoneEditText.setEnabled(false);
-        bioEditText.setFocusableInTouchMode(false);
-        bioEditText.clearFocus();
+        bioEditText.setKeyListener(null); // bio edittext won't listen to new keys (cant edit it)
 
         usernameEditText.setText(currentUser.getUserName());
         dogNameEditText.setText(currentUser.getUserDogName());
@@ -147,12 +151,12 @@ public class ProfilePageActivity extends AppCompatActivity {
     private void setViewsByState(boolean isEditState) {
         if (isEditState) {
             btnCancelEdit.setVisibility(View.VISIBLE);
+            bioEditText.setKeyListener(bioEditTextKeyListener); // bio edittext will listen to new keys (enable to edit it)
         } else {
             btnCancelEdit.setVisibility(View.GONE);
+            bioEditText.setKeyListener(null); // bio edittext won't listen to new keys (cant edit it)
         }
         dogNameEditText.setEnabled(isEditState);
-        bioEditText.setFocusableInTouchMode(isEditState);
-        bioEditText.clearFocus();
         emailEditText.setEnabled(isEditState);
         phoneEditText.setEnabled(isEditState);
         int edit_ic = isEditState ? R.drawable.ic_save_profile : R.drawable.ic_edit_profile;

--- a/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
+++ b/app/src/main/java/communi/dog/aplicatiion/ProfilePageActivity.java
@@ -23,17 +23,15 @@ public class ProfilePageActivity extends AppCompatActivity {
     private EditText phoneEditText;
     private EditText bioEditText;
     private ImageView btnEditProfile;
-    private TextView btnMyMarker;
-    private ImageButton btnBackToMap;
     private ImageView btnCancelEdit;
     private boolean isEdit = false;
     private DB appDB;
-    private KeyListener bioEditTextKeyListener;
 
     private String dogNameBeforeEdit;
     private String emailBeforeEdit;
     private String phoneBeforeEdit;
     private String bioBeforeEdit;
+    private KeyListener bioEditTextKeyListener;
 
 
     @Override
@@ -50,11 +48,9 @@ public class ProfilePageActivity extends AppCompatActivity {
         bioEditText = findViewById(R.id.profile_bio);
         bioEditTextKeyListener = bioEditText.getKeyListener();
 
-        btnMyMarker = findViewById(R.id.profile_to_my_marker);
-        btnBackToMap = findViewById(R.id.backToMapFromProfile);
+        TextView btnMyMarker = findViewById(R.id.profile_to_my_marker);
+        ImageButton btnBackToMap = findViewById(R.id.backToMapFromProfile);
         btnCancelEdit = findViewById(R.id.btnCancelEditProfile);
-        // getting the profile bio edit text key listener. (this way we will enable and disable the
-        // option to edit it)
         btnEditProfile = findViewById(R.id.btnEditProfile);
 
         dogNameEditText.setEnabled(false);
@@ -85,7 +81,8 @@ public class ProfilePageActivity extends AppCompatActivity {
                         currentUser.getUserName(),
                         phoneEditText.getText().toString(),
                         dogNameEditText.getText().toString(),
-                        bioEditText.getText().toString());
+                        bioEditText.getText().toString(), currentUser.isManager(),
+                        currentUser.isApproved());
             } else {
                 dogNameBeforeEdit = dogNameEditText.getText().toString();
                 emailBeforeEdit = emailEditText.getText().toString();
@@ -151,7 +148,7 @@ public class ProfilePageActivity extends AppCompatActivity {
     private void setViewsByState(boolean isEditState) {
         if (isEditState) {
             btnCancelEdit.setVisibility(View.VISIBLE);
-            bioEditText.setKeyListener(bioEditTextKeyListener); // bio edittext will listen to new keys (enable to edit it)
+            bioEditText.setKeyListener(bioEditTextKeyListener); // bio edittext won't listen to new keys (cant edit it)
         } else {
             btnCancelEdit.setVisibility(View.GONE);
             bioEditText.setKeyListener(null); // bio edittext won't listen to new keys (cant edit it)
@@ -176,12 +173,6 @@ public class ProfilePageActivity extends AppCompatActivity {
         AlertDialog alertDialog = builder.create();
         alertDialog.show();
     }
-
-//    private void backToMap() {
-//        Intent backToMapIntent = new Intent(ProfilePageActivity.this, MapScreenActivity.class);
-//        backToMapIntent.putExtra("center_to_my_location", false);
-//        startActivity(backToMapIntent);
-//    }
 
     @Override
     public void onBackPressed() {


### PR DESCRIPTION
Fixed bug #67.
The problem was that you disable the edittext (where bio is) when the user is not in edit mode.
When edittext is disable you cant scroll down.
The fix is: when edit mode is disable, only disable the editable of the edittext but allowing scrolling.